### PR TITLE
Remove unconvential torch alias, and tweak docstring format

### DIFF
--- a/poptorch_experimental_addons/_impl/sparse.py
+++ b/poptorch_experimental_addons/_impl/sparse.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
-"""Static sparse-dense matrix multiplication.
+"""
+Static sparse-dense matrix multiplication.
 
 These APIs are based on a block COO format, created as:
 ```python
-T.sparse_coo_tensor(indices, values, size=(n_rows, n_cols))
+torch.sparse_coo_tensor(indices, values, size=(n_rows, n_cols))
 #   indices -- shape (2, nnz_blocks) -- row and column block indices
 #   values -- shape (nnz_blocks, block_size, block_size)
 ```
@@ -17,17 +18,18 @@ from dataclasses import dataclass
 
 import numpy as np
 import poptorch
-import torch as T
+import torch
+from torch import Tensor
 
 # Low-level API
 
 
-def block_coo_transpose(tensor: T.Tensor) -> T.Tensor:
+def block_coo_transpose(tensor: Tensor) -> Tensor:
     """The 2D matrix transpose of a block sparse tensor."""
     return tensor.permute(1, 0, 3, 2).coalesce()
 
 
-def block_coo_to_dense(tensor: T.Tensor) -> T.Tensor:
+def block_coo_to_dense(tensor: Tensor) -> Tensor:
     """Convert a block sparse tensor to dense."""
     if tensor.sparse_dim() != tensor.dense_dim():
         raise ValueError(
@@ -45,13 +47,14 @@ def block_coo_to_dense(tensor: T.Tensor) -> T.Tensor:
     return tensor.to_dense().permute(permutation).reshape(shape)
 
 
-def block_coo_spmm(sparse: T.Tensor, dense: T.Tensor, mode: str) -> T.Tensor:
-    """A block-COO matrix multiplication.
+def block_coo_spmm(sparse: Tensor, dense: Tensor, mode: str) -> Tensor:
+    """
+    A block-COO matrix multiplication.
 
     - if `mode=="sparse_dense"`, `y = sparse @ dense`
     - if `mode=="dense_sparse"`, `y = dense @ sparse`
 
-    sparse -- T.sparse_coo_tensor -- should be coalesced, dimensions
+    sparse -- torch.sparse_coo_tensor -- should be coalesced, dimensions
               `(blocks_row, blocks_col, block_size_row, block_size_col)`
     """
     if poptorch.isRunningOnIpu():
@@ -59,12 +62,13 @@ def block_coo_spmm(sparse: T.Tensor, dense: T.Tensor, mode: str) -> T.Tensor:
     return block_coo_spmm_gs(sparse, dense, mode)
 
 
-def block_coo_spmm_gs(sparse: T.Tensor, dense: T.Tensor, mode: str) -> T.Tensor:
-    """Implement a block sparse COO matmul "manually" using gather-multiply-scatter.
+def block_coo_spmm_gs(sparse: Tensor, dense: Tensor, mode: str) -> Tensor:
+    """
+    Implement a block sparse COO matmul "manually" using gather-multiply-scatter.
 
     See `block_coo_spmm()`.
     """
-    if sparse.layout != T.sparse_coo:
+    if sparse.layout != torch.sparse_coo:
         raise ValueError(f"Expected sparse_coo `lhs`, actual layout: {sparse.layout}")
 
     if mode == "sparse_dense":
@@ -94,8 +98,8 @@ def block_coo_spmm_gs(sparse: T.Tensor, dense: T.Tensor, mode: str) -> T.Tensor:
     # 2. Multiply
     products = lhs.values() @ inputs
     # 3. Scatter
-    output = T.scatter_add(
-        T.zeros(blocks_out, block_size_out, batch_size, dtype=rhs.dtype),
+    output = torch.scatter_add(
+        torch.zeros(blocks_out, block_size_out, batch_size, dtype=rhs.dtype),
         dim=0,
         index=indices_out[:, None, None].expand(-1, block_size_out, batch_size),
         src=products,
@@ -104,8 +108,9 @@ def block_coo_spmm_gs(sparse: T.Tensor, dense: T.Tensor, mode: str) -> T.Tensor:
     return output.T if mode == "dense_sparse" else output
 
 
-def block_coo_spmm_ipu(sparse: T.Tensor, dense: T.Tensor, mode: str) -> T.Tensor:
-    """IPU-only spmm using `popsparse::static_::matMul`.
+def block_coo_spmm_ipu(sparse: Tensor, dense: Tensor, mode: str) -> Tensor:
+    """
+    IPU-only spmm using `popsparse::static_::matMul`.
 
     See `block_coo_spmm()`.
     """
@@ -114,9 +119,9 @@ def block_coo_spmm_ipu(sparse: T.Tensor, dense: T.Tensor, mode: str) -> T.Tensor
         raise ValueError(
             "Expected block_coo_spmm_ipu mode either 'sparse_dense' or 'dense_sparse'"
         )
-    if sparse.layout != T.sparse_coo:
+    if sparse.layout != torch.sparse_coo:
         raise ValueError(
-            "block_coo_spmm_ipu requires `sparse` to be T.sparse_coo_tensor"
+            "block_coo_spmm_ipu requires `sparse` to be torch.sparse_coo_tensor"
             f", actual {sparse.layout}"
         )
     if sparse.sparse_dim() != 2 or sparse.dense_dim() != 2:
@@ -144,13 +149,15 @@ def block_coo_spmm_ipu(sparse: T.Tensor, dense: T.Tensor, mode: str) -> T.Tensor
     row_indices, col_indices = sparse.indices().numpy()
     nzvalues = sparse.values().numpy().flatten()
 
-    y: T.Tensor
+    y: Tensor
     (y,) = poptorch.custom_op(
         [dense],
         name="StaticSparseMatmul",
         domain="ai.graphcore",
         domain_version=1,
-        example_outputs=[T.zeros(output_shape, dtype=dense.dtype, device=dense.device)],
+        example_outputs=[
+            torch.zeros(output_shape, dtype=dense.dtype, device=dense.device)
+        ],
         attributes=dict(
             mode=mode,
             n_rows=sparse.shape[0] * sparse.shape[2],
@@ -172,33 +179,35 @@ def block_coo_spmm_ipu(sparse: T.Tensor, dense: T.Tensor, mode: str) -> T.Tensor
 class StaticSparseMatrix:
     """Convenience wrapper for `dense @ sparse` or `sparse @ dense`."""
 
-    matrix: T.Tensor
+    matrix: Tensor
 
-    def __matmul__(self, rhs: T.Tensor) -> T.Tensor:
+    def __matmul__(self, rhs: Tensor) -> Tensor:
         return block_coo_spmm(self.matrix, rhs, mode="sparse_dense")
 
-    def __rmatmul__(self, lhs: T.Tensor) -> T.Tensor:
+    def __rmatmul__(self, lhs: Tensor) -> Tensor:
         return block_coo_spmm(self.matrix, lhs, mode="dense_sparse")
 
 
-class StaticSparseLinear(T.nn.Module):
-    """A linear layer with frozen sparse parameters.
+class StaticSparseLinear(torch.nn.Module):
+    """
+    A linear layer with frozen sparse parameters.
 
     weight -- shape `(out_features, in_features)`
     """
 
-    def __init__(self, weight: T.Tensor):
+    def __init__(self, weight: Tensor):
         super().__init__()
         self.weight = weight
 
-    def forward(self, x: T.Tensor) -> T.Tensor:
+    def forward(self, x: Tensor) -> Tensor:
         return (StaticSparseMatrix(self.weight) @ x.T).T
 
 
 def magnitude_prune(
-    matrix: T.Tensor, block_size: int, density: float, ord: int = 2
-) -> T.Tensor:
-    """Basic single-tensor block magnitude pruning.
+    matrix: Tensor, block_size: int, density: float, ord: int = 2
+) -> Tensor:
+    """
+    Basic single-tensor block magnitude pruning.
 
     Groups `matrix` into blocks of size `block_size x block_size`, then
     creates a sparse COO tensor retaining the largest-magnitude blocks
@@ -213,11 +222,11 @@ def magnitude_prune(
         matrix.shape[1] // block_size,
         block_size,
     )
-    norms = T.linalg.norm(blocks.float(), ord=ord, dim=(1, 3))
+    norms = torch.linalg.norm(blocks.float(), ord=ord, dim=(1, 3))
     nnz_blocks = int(density * matrix.nelement() / block_size**2)
-    topk = T.topk(norms.view(-1), nnz_blocks).indices
-    indices = T.stack([topk // norms.shape[1], topk % norms.shape[1]])
-    return T.sparse_coo_tensor(
+    topk = torch.topk(norms.view(-1), nnz_blocks).indices
+    indices = torch.stack([topk // norms.shape[1], topk % norms.shape[1]])
+    return torch.sparse_coo_tensor(
         indices=indices,
         values=blocks[indices[0], :, indices[1], :],
         size=blocks.permute(0, 2, 1, 3).shape,


### PR DESCRIPTION
I've left single-line docstrings as `"""..."""` because it looks a bit weird to me to have newlines there - but what do you think?