### PR TITLE
SDK 3.2.0 compatibility

### DIFF
--- a/.devcontainer.dockerfile
+++ b/.devcontainer.dockerfile
@@ -1,4 +1,4 @@
-FROM graphcore/pytorch:3.1.0-ubuntu-20.04
+FROM graphcore/pytorch:3.2.0-ubuntu-20.04
 
 RUN apt-get update \
     && apt-get install -y \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    container: graphcore/pytorch:3.1.0-ubuntu-20.04
+    container: graphcore/pytorch:3.2.0-ubuntu-20.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A collection of addons to [PopTorch](https://github.com/graphcore/poptorch), wit
 See [documentation](https://graphcore-research.github.io/poptorch-experimental-addons).
 
 ```bash
-# Tested on Poplar SDK 3.1.0+1205, Ubuntu 20.04, Python 3.8
+# Tested on Poplar SDK 3.2.0+1277, Ubuntu 20.04, Python 3.8
 pip install git+https://github.com/graphcore-research/poptorch-experimental-addons
 
 # Run an example

--- a/poptorch_experimental_addons/cpp/replicatedallreducetp.cpp
+++ b/poptorch_experimental_addons/cpp/replicatedallreducetp.cpp
@@ -6,7 +6,6 @@ For the op to work you need to run the `OpToIdentityPattern` after autodiffing t
 
 #include <map>
 #include <memory>
-#include <snap/Tensor.hpp>
 #include <vector>
 
 #pragma GCC diagnostic push

--- a/poptorch_experimental_addons/cpp/replicatedallreducetp.cpp
+++ b/poptorch_experimental_addons/cpp/replicatedallreducetp.cpp
@@ -25,8 +25,8 @@ For the op to work you need to run the `OpToIdentityPattern` after autodiffing t
 #include <popart/popx/devicex.hpp>
 #include <popart/popx/irlowering.hpp>
 #include <popart/popx/op/collectives/replicatedallreducex.hpp>
-#include <popart/popx/opxmanager.hpp>
 #include <popart/popx/opx.hpp>
+#include <popart/popx/opxmanager.hpp>
 #include <popart/region.hpp>
 #include <popart/tensor.hpp>
 #include <popart/util.hpp>

--- a/poptorch_experimental_addons/cpp/replicatedallreducetp.cpp
+++ b/poptorch_experimental_addons/cpp/replicatedallreducetp.cpp
@@ -26,7 +26,7 @@ For the op to work you need to run the `OpToIdentityPattern` after autodiffing t
 #include <popart/popx/irlowering.hpp>
 #include <popart/popx/op/collectives/replicatedallreducex.hpp>
 #include <popart/popx/opxmanager.hpp>
-#include <popart/popx/popopx.hpp>
+#include <popart/popx/opx.hpp>
 #include <popart/region.hpp>
 #include <popart/tensor.hpp>
 #include <popart/util.hpp>


### PR DESCRIPTION
After snap deprecation in new release, this seems to be the only necessary change to build PEA with SDK 3.2.0+1277.

What about CI? Do we want to update the container to use new SDK?