### PR TITLE
Fix distance_matrix in float16

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
-from typing import Callable, Dict
+from typing import Callable, Dict, cast
 
 import poptorch
 import pytest
@@ -76,8 +76,8 @@ def test_distance_matrix(p: int, dtype: torch.dtype) -> None:
         device="ipu",
     )
     output_torch = run_forward_and_backward(
-        lambda tensor1, tensor2: torch.norm(
-            tensor1[:, None] - tensor2[None, :], p=p, dim=-1
+        lambda tensor1, tensor2: cast(
+            torch.Tensor, (tensor1[:, None] - tensor2[None, :]).norm(p=p, dim=-1)
         ),
         dict(tensor1=tensor1, tensor2=tensor2),
         patterns={},


### PR DESCRIPTION
CC @lyprince, who first spotted this.

A big oversight made me forget to check the custom op in float16, and indeed it did not work - due to me forgetting to update the connections in distance_matrix.cpp when we changed the l1/l2 distance codelet to always return floats. I added the missing piece (taking it from the poplar-distributed-kge repo) and changed the test of the op to run in both float and half.