### PR TITLE
Implement FPX quantisation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OBJDIR ?= $(dir $(OUT))obj
 CXXFLAGS = -Wall -Wextra -Werror -std=c++17 -O2 -g -fPIC -DONNX_NAMESPACE=onnx
 LIBS = -lpoplar -lpopart -lpopops -lpopsparse -lpoputil -lgcl
 
-OBJECTS = $(OBJDIR)/static_spmm.o $(OBJDIR)/autograd_proxy.o $(OBJDIR)/replicatedallreducetp.o $(OBJDIR)/distance_matrix.o $(OBJDIR)/replicatedalltoall.o
+OBJECTS = $(OBJDIR)/static_spmm.o $(OBJDIR)/autograd_proxy.o $(OBJDIR)/replicatedallreducetp.o $(OBJDIR)/distance_matrix.o $(OBJDIR)/replicatedalltoall.o $(OBJDIR)/simulated_quant.o
 
 # Rules
 

--- a/dev
+++ b/dev
@@ -54,9 +54,10 @@ def build() -> None:
     run(["make", "-j"])
 
 
+@cli("-s", "--no-capture", action="store_false", dest="capture")
 @cli("-k", "--filter")
 @cli("--gdb", action="store_true")
-def tests(filter: Optional[str], gdb: bool) -> None:
+def tests(capture: bool, filter: Optional[str], gdb: bool) -> None:
     """run Python tests"""
     build()
     run(
@@ -67,6 +68,7 @@ def tests(filter: Optional[str], gdb: bool) -> None:
             "tests",
             None if filter else "--cov=poptorch_experimental_addons",
             *(["-k", filter] if filter else []),
+            None if capture else "-s",
         ],
         gdb=gdb,
     )
@@ -158,7 +160,7 @@ def doc() -> None:
 def ci(skip: List[str] = []) -> None:
     """run all continuous integration tests & checks"""
     if "tests" not in skip:
-        tests(filter=None, gdb=False)
+        tests(capture=True, filter=None, gdb=False)
     if "lint" not in skip:
         lint()
     if "format" not in skip:

--- a/poptorch_experimental_addons/_impl/core.py
+++ b/poptorch_experimental_addons/_impl/core.py
@@ -5,7 +5,7 @@ Top-level utilities.
 """
 
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
 
 import poptorch
 import torch
@@ -102,7 +102,7 @@ def distance_matrix(tensor1: Tensor, tensor2: Tensor, p: int) -> Tensor:
                     device=tensor1.device,
                 )
             ],
-            attributes=dict(root_path=str(Path(__file__).parent.parent)),
+            attributes=dict(root_path=str(Path(__file__).parent.parent.absolute())),
         )
     else:
         y = torch.cdist(tensor1, tensor2, p=p)
@@ -110,4 +110,149 @@ def distance_matrix(tensor1: Tensor, tensor2: Tensor, p: int) -> Tensor:
     return y
 
 
-__all__ = ["autograd_proxy", "distance_matrix"]
+def quantise_fpx(
+    x: Tensor,
+    exponent_bits: int,
+    mantissa_bits: int,
+    rounding: str = "stochastic",
+    fwd: bool = True,
+    bwd: Optional[bool] = None,
+) -> Tensor:
+    """
+    Quantise the values in a tensor to a lower-precision floating point format.
+    Note that this is not a cast; the returned tensor has the same dtype as the input.
+
+        quantise_fpx(tensor(0.2), exponent_bits=2, mantissa_bits=1, rounding="nearest")
+           => 0.25
+
+    By default, quantise in the forward pass and return no gradient.
+
+    exponent_bits, mantissa_bits -- define the FP format (total bits = 1 (sign) + E + M)
+
+    rounding -- either "nearest" or "stochastic"
+
+    fwd -- whether to quantise the forward value
+
+    bwd -- whether to generate & whether to quantise the gradient:
+           bwd=None  -- no gradient
+           bwd=False -- unquantised gradient (straight-through estimator)
+           bwd=True  -- quantised gradient
+    """
+    if rounding not in ["nearest", "stochastic"]:
+        raise ValueError(
+            "Expected quantise(rounding=?) to be 'nearest' or 'stochastic'"
+            f", actual '{rounding}'"
+        )
+
+    q: Tensor
+    if poptorch.isRunningOnIpu():
+        (q,) = poptorch.custom_op(
+            name="SimulatedQuant",
+            domain_version=1,
+            domain="ai.graphcore",
+            inputs=[x],
+            example_outputs=[x],
+            attributes=dict(
+                root_path=str(Path(__file__).parent.parent.absolute()),
+                exponent_bits=exponent_bits,
+                mantissa_bits=mantissa_bits,
+                rounding=rounding,
+                fwd=fwd,
+                bwd={True: "quantise", False: "ste", None: "stop"}[bwd],
+            ),
+        )
+        return q
+
+    def _quantise(x: Tensor) -> Tensor:
+        max_exponent = 2 ** (exponent_bits - 1) - 1
+        absmax = 2**max_exponent * (2 - 2**-mantissa_bits)
+        downscale = 2.0 ** (126 - max_exponent)
+        mask = torch.tensor(
+            2 ** (23 - mantissa_bits) - 1, dtype=torch.int32, device=x.device
+        )
+        offset = (
+            torch.randint(  # type:ignore[call-overload]
+                0, mask + 1, x.shape, dtype=torch.int32, device=x.device
+            )
+            if rounding == "stochastic"
+            else mask // 2
+        )
+        # Manually clip to max
+        # Then scale down (to generate appropriate subnormals) & mask off mantissa bits
+        q = x.to(torch.float32)
+        q = torch.clip(x, -absmax, absmax)
+        q /= downscale
+        q = ((q.view(torch.int32) + offset) & ~mask).view(torch.float32)
+        q *= downscale
+        q = q.to(x.dtype)
+        return q
+
+    class F(torch.autograd.Function):
+        @staticmethod
+        def forward(  # type:ignore[override]
+            ctx: torch.autograd.function.FunctionCtx, xx: Tensor
+        ) -> Tensor:
+            return _quantise(xx) if fwd else xx.clone()
+
+        @staticmethod
+        def backward(  # type:ignore[override]
+            ctx: torch.autograd.function.FunctionCtx, grad_y: Tensor
+        ) -> Optional[Tensor]:
+            if bwd is not None:
+                return _quantise(grad_y) if bwd else grad_y
+            return None
+
+    q = F.apply(x)  # type:ignore[no-untyped-call]
+    return q
+
+
+def quantise_fpx_ste(
+    x: Tensor,
+    exponent_bits: int,
+    mantissa_bits: int,
+    rounding: str = "stochastic",
+) -> Tensor:
+    """
+    Quantise the forward value while leaving the gradient unchanged, as a
+    straight-through estimator.
+
+    See `quantise_fpx` for more detail.
+    """
+    return quantise_fpx(
+        x,
+        exponent_bits=exponent_bits,
+        mantissa_bits=mantissa_bits,
+        rounding=rounding,
+        fwd=True,
+        bwd=False,
+    )
+
+
+def quantise_fpx_grad(
+    x: Tensor,
+    exponent_bits: int,
+    mantissa_bits: int,
+    rounding: str = "stochastic",
+) -> Tensor:
+    """
+    Quantise the gradient while leaving the forward value unchanged.
+
+    See `quantise_fpx` for more detail.
+    """
+    return quantise_fpx(
+        x,
+        exponent_bits=exponent_bits,
+        mantissa_bits=mantissa_bits,
+        rounding=rounding,
+        fwd=False,
+        bwd=True,
+    )
+
+
+__all__ = [
+    "autograd_proxy",
+    "distance_matrix",
+    "quantise_fpx",
+    "quantise_fpx_ste",
+    "quantise_fpx_grad",
+]

--- a/poptorch_experimental_addons/_impl/core.py
+++ b/poptorch_experimental_addons/_impl/core.py
@@ -144,6 +144,23 @@ def quantise_fpx(
             f", actual '{rounding}'"
         )
 
+    if poptorch.isRunningOnIpu():
+        max_exponent_bits = 5
+        max_mantissa_bits = 10
+    else:
+        max_exponent_bits = 8
+        max_mantissa_bits = 23
+    if exponent_bits > max_exponent_bits:
+        raise ValueError(
+            f"quantise_fpx(exponent_bits={exponent_bits}) not supported, maximum"
+            f" number of exponent bits is {max_exponent_bits}"
+        )
+    if mantissa_bits > max_mantissa_bits:
+        raise ValueError(
+            f"quantise_fpx(mantissa_bits={mantissa_bits}) not supported, maximum"
+            f" number of mantissa bits is {max_mantissa_bits}"
+        )
+
     q: Tensor
     if poptorch.isRunningOnIpu():
         (q,) = poptorch.custom_op(

--- a/poptorch_experimental_addons/cpp/simulated_quant.cpp
+++ b/poptorch_experimental_addons/cpp/simulated_quant.cpp
@@ -1,0 +1,182 @@
+// Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+
+#include <cmath>
+#include <memory>
+
+#include <poplar/Graph.hpp>
+#include <popops/Cast.hpp>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include <popart/op.hpp>
+#include <popart/opmanager.hpp>
+#include <popart/opserialiser.hpp>
+#include <popart/popx/opx.hpp>
+#include <popart/popx/opxmanager.hpp>
+#pragma GCC diagnostic pop
+
+namespace {
+
+poplar::Tensor quantise(poplar::Graph& graph,
+                        const poplar::Tensor& input,
+                        unsigned exponentBits,
+                        unsigned mantissaBits,
+                        bool stochasticRounding,
+                        poplar::program::Sequence& prog,
+                        const poplar::DebugContext& debugContext) {
+    auto halfInput = input;
+    if (input.elementType() != poplar::HALF) {
+        halfInput = popops::cast(graph, input, poplar::HALF, prog, {debugContext, "toHalf"});
+    }
+    int maxExponent = (1 << (exponentBits - 1)) - 1;
+    auto absMax = static_cast<float>(std::pow(2.0, maxExponent) *
+                                     (2 - std::pow(2.0, -static_cast<double>(mantissaBits))));
+    // std::max accounts for E5M2 which has a larger range (smaller min normal) than FP16
+    // (this means we probably lose some values in this range)
+    auto downscale = std::max(1.0f, static_cast<float>(std::pow(2.0, 14 - maxExponent)));
+    auto mask = static_cast<unsigned short>((1u << (10 - mantissaBits)) - 1);
+
+    auto cs = graph.addComputeSet(debugContext);
+    auto tileMapping = graph.getTileMapping(halfInput);
+    auto output = graph.clone(halfInput);
+    for (auto tile = 0u; tile < tileMapping.size(); ++tile) {
+        auto tileAbsMax = graph.addConstant<float>(poplar::HALF, {}, absMax);
+        auto tileDownscale = graph.addConstant<float>(poplar::HALF, {}, downscale);
+        auto tileMask = graph.addConstant<unsigned short>(poplar::UNSIGNED_SHORT, {}, mask);
+        graph.setTileMapping(tileAbsMax, tile);
+        graph.setTileMapping(tileDownscale, tile);
+        graph.setTileMapping(tileMask, tile);
+        for (auto& interval : tileMapping[tile]) {
+            auto out = output.flatten().slice(interval);
+            auto vertexName = stochasticRounding ? "CustomQuant<RoundingMode::Stochastic>"
+                                                 : "CustomQuant<RoundingMode::Nearest>";
+            graph.setTileMapping(graph.addVertex(cs, vertexName,
+                                                 {{"input", halfInput.flatten().slice(interval)},
+                                                  {"output", out},
+                                                  {"absMax", tileAbsMax},
+                                                  {"downscale", tileDownscale},
+                                                  {"mask", tileMask}}),
+                                 tile);
+        }
+    }
+    prog.add(poplar::program::Execute(cs, debugContext));
+    if (input.elementType() != poplar::HALF) {
+        return popops::cast(graph, output, poplar::FLOAT, prog, {debugContext, "toFloat"});
+    }
+    return output;
+}
+
+struct Config {
+    std::string rootPath;
+    unsigned exponentBits;
+    unsigned mantissaBits;
+    std::string rounding;
+    bool fwd;
+    std::string bwd;  // "quantise|ste|stop"
+};
+
+struct Op : popart::Op {
+    static const popart::OperatorIdentifier ID;
+    Config config;
+
+    explicit Op(const popart::OperatorIdentifier& opid_,
+                const popart::Op::Settings& settings_,
+                const Config& config)
+        : popart::Op(opid_, settings_), config(config) {}
+
+    // Basics
+    std::unique_ptr<popart::Op> clone() const final { return std::make_unique<Op>(*this); }
+    float getSubgraphValue() const final { return getLowSubgraphValue(); }
+    void setup() final { outInfo(0) = inInfo(0); }
+    std::vector<std::unique_ptr<popart::Op>> getGradOps() {
+        std::vector<std::unique_ptr<popart::Op>> gradOps;
+        if (config.bwd != "stop") {
+            auto gradConfig = config;
+            gradConfig.fwd = (config.bwd == "quantise");
+            gradOps.emplace_back(new Op(ID, settings, gradConfig));
+        }
+        return gradOps;
+    }
+    bool requiresRandomSeed() const override { return true; }
+    // Grad properties
+    const std::vector<popart::GradInOutMapper>& gradInputInfo() const {
+        static const std::vector<popart::GradInOutMapper> info = {
+            {0, 0, popart::GradOpInType::GradOut}};
+        return info;
+    }
+    const std::map<int, int>& gradOutToNonGradIn() const {
+        static const std::map<int, int> info = {{0, 0}};
+        return info;
+    }
+    // Attributes for hashing
+    void appendAttributes(popart::OpSerialiserBase& os) const final {
+        popart::Op::appendAttributes(os);
+        appendAttributesImpl(os);
+    }
+    void appendOutlineAttributes(popart::OpSerialiserBase& os) const final {
+        popart::Op::appendOutlineAttributes(os);
+        appendAttributesImpl(os);
+    }
+
+   private:
+    void appendAttributesImpl(popart::OpSerialiserBase& os) const {
+        os.appendAttribute("rootPath", config.rootPath);
+        os.appendAttribute("exponentBits", config.exponentBits);
+        os.appendAttribute("mantissaBits", config.mantissaBits);
+        os.appendAttribute("rounding", config.rounding);
+        os.appendAttribute("fwd", config.fwd);
+        os.appendAttribute("bwd", config.bwd);
+    }
+};
+
+// Note that we can reuse the Opx for the grad.
+struct Opx : popart::popx::Opx {
+    Opx(popart::Op* op, popart::popx::Devicex* devicex) : popart::popx::Opx(op, devicex) {
+        verifyOp<Op>(op, Op::ID);
+        graph().addCodelets(getOp<Op>().config.rootPath + "/cpp/simulated_quant_codelet.cpp");
+    }
+    void grow(poplar::program::Sequence& prog) const final {
+        auto input = get(inId(0));
+        auto& op = getOp<Op>();
+        if (op.config.fwd) {
+            insert(outId(0),
+                   quantise(graph(), input, op.config.exponentBits, op.config.mantissaBits,
+                            op.config.rounding == "stochastic", prog, debugContext()));
+        } else {
+            // Since we never declare input/output aliases, we must create a copy
+            auto output = graph().clone(input);
+            prog.add(poplar::program::Copy(input, output, /*dontOutline*/ false, debugContext()));
+            insert(outId(0), output);
+        }
+    }
+};
+
+const popart::OperatorIdentifier Op::ID = {"ai.graphcore", "SimulatedQuant", 1};
+popart::OpDefinition::DataTypes T = {popart::DataType::FLOAT, popart::DataType::FLOAT16};
+popart::OpCreator<Op> opCreator(
+    {{Op::ID,
+      {popart::OpDefinition::Inputs({{"input", T}}), popart::OpDefinition::Outputs({{"output", T}}),
+       popart::OpDefinition::Attributes({{"root_path", {"string"}},
+                                         {"exponent_bits", {"int"}},
+                                         {"mantissa_bits", {"int"}},
+                                         {"rounding", {"string"}},
+                                         {"fwd", {"int"}},
+                                         {"bwd", {"string"}}})}}},
+    [](const popart::OpCreatorInfo& info) {
+        auto rootPath = info.attributes.getAttribute<popart::Attributes::String>("root_path");
+        auto exponentBits =
+            unsigned(info.attributes.getAttribute<popart::Attributes::Int>("exponent_bits"));
+        auto mantissaBits =
+            unsigned(info.attributes.getAttribute<popart::Attributes::Int>("mantissa_bits"));
+        auto rounding = info.attributes.getAttribute<popart::Attributes::String>("rounding");
+        auto fwd = bool(info.attributes.getAttribute<popart::Attributes::Int>("fwd"));
+        auto bwd = info.attributes.getAttribute<popart::Attributes::String>("bwd");
+        return std::make_unique<Op>(
+            info.opid, info.settings,
+            Config{rootPath, exponentBits, mantissaBits, rounding, fwd, bwd});
+    },
+    true);
+popart::popx::OpxCreator<Opx> opxCreator({Op::ID});
+
+}  // namespace

--- a/poptorch_experimental_addons/cpp/simulated_quant_codelet.cpp
+++ b/poptorch_experimental_addons/cpp/simulated_quant_codelet.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+
+#include <algorithm>
+#include <cmath>
+#include <ipu_intrinsics>
+
+#include <poplar/Vertex.hpp>
+
+enum class RoundingMode { Nearest, Stochastic };
+
+namespace {
+
+// Helpers
+template <class R, class T>
+R as(T x) {
+    return *reinterpret_cast<R*>(&x);
+}
+half4 andc(half4 a, half4 b) {
+    return as<half4>(ipu::andc(as<float2>(a), as<float2>(b)));
+}
+half4 toHalf4(half a) {
+    return half4{a, a, a, a};
+}
+typedef uint32_t uintv2 __attribute__((vector_size(sizeof(uint32_t) * 2)));
+uintv2 repeat4(uint16_t x) {
+    auto x32 = static_cast<uint32_t>(x);
+    return uintv2{(x32 << 16) | x32, (x32 << 16) | x32};
+}
+
+// Core quantisation functions
+template <RoundingMode Rounding>
+half4 quantise4(half4 x, half absMax, half downscale, uint16_t mask) {
+    x = ipu::clamp(x, half2{-absMax, absMax});
+    x /= downscale;
+    uintv2 offset;
+    switch (Rounding) {
+        case RoundingMode::Nearest:
+            offset = repeat4(mask / 2);
+            break;
+        case RoundingMode::Stochastic:
+            offset = {__builtin_ipu_urand32(), __builtin_ipu_urand32()};
+            offset &= repeat4(mask);
+            break;
+    }
+    // If a 16-bit integer add overflows, we have bigger problems than the int32 packing
+    x = as<half4>(as<uintv2>(x) + offset);
+    x = andc(x, toHalf4(as<half>(mask)));
+    x *= downscale;
+    return x;
+}
+// Note that we can't reuse `quantise4` here, otherwise we get slower code using function
+// calls (non-inlined)
+template <RoundingMode Rounding>
+half quantise1(half x, half absMax, half downscale, uint16_t mask) {
+    x = ipu::clamp(half2{x, 0}, half2{-absMax, absMax})[0];
+    x /= downscale;
+    auto offset = (Rounding == RoundingMode::Stochastic)
+                      ? static_cast<uint16_t>(__builtin_ipu_urand32()) & mask
+                      : (mask / 2);
+    x = as<half>((as<uint16_t>(x) + offset) & ~mask);
+    x *= downscale;
+    return x;
+}
+
+// Loop
+template <RoundingMode Rounding>
+void quantise_loop(const half* __restrict__ input,
+                   unsigned n,
+                   half absMax,
+                   half downscale,
+                   uint16_t mask,
+                   half* __restrict__ output) {
+    for (auto i = 0u; i < n / 4; ++i) {
+        reinterpret_cast<half4*>(output)[i] =
+            quantise4<Rounding>(reinterpret_cast<const half4*>(input)[i], absMax, downscale, mask);
+    }
+    for (auto i = 4 * (n / 4); i < n; ++i) {
+        output[i] = quantise1<Rounding>(input[i], absMax, downscale, mask);
+    }
+}
+}  // namespace
+
+template <RoundingMode Rounding>
+struct CustomQuant : poplar::MultiVertex {
+    poplar::Input<poplar::Vector<half, poplar::VectorLayout::SPAN, 8>> input;
+    poplar::Output<poplar::Vector<half, poplar::VectorLayout::COMPACT_PTR, 8>> output;
+    poplar::Input<half> absMax;
+    poplar::Input<half> downscale;
+    poplar::Input<uint16_t> mask;
+
+    bool compute(unsigned id) {
+        auto grainSize = 4 * numWorkers();
+        auto blockSize = 4 * ((input.size() + grainSize - 1) / grainSize);
+        auto start = std::min(blockSize * id, input.size());
+        auto end = std::min(blockSize * (id + 1), input.size());
+        quantise_loop<Rounding>(input.data() + start, end - start, *absMax, *downscale, *mask,
+                                output.data() + start);
+        return true;
+    }
+};
+
+template struct CustomQuant<RoundingMode::Nearest>;
+template struct CustomQuant<RoundingMode::Stochastic>;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -185,7 +185,7 @@ def test_quantisation_variants(device: str) -> None:
         }
 
     x = torch.linspace(-1e5, 1e5, steps=1000)
-    grad_y = torch.flip(x, (0,))
+    grad_y = torch.flip(x, (0,))  # different grads, same range
     out = run_forward_and_backward(
         _fn,
         {name: x for name in ["x", "x_ste", "x_grad_only"]},

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 
-from typing import Callable, Dict, cast
+import collections
+from typing import Callable, Dict, Tuple
 
 import poptorch
 import pytest
@@ -11,52 +12,61 @@ import poptorch_experimental_addons as pea
 
 
 def run_forward_and_backward(
-    fn: Callable[..., Tensor],
-    args: Dict[str, Tensor],
-    patterns: Dict[str, bool],
+    fn: Callable[..., Dict[str, Tensor]],
+    inputs: Dict[str, Tensor],
     device: str,
+    grad_outputs: Dict[str, Tensor] = {},
+    patterns: Dict[str, bool] = {},
 ) -> Dict[str, Tensor]:
     class TestModule(nn.Module):
         def __init__(self) -> None:
             super().__init__()
-            for k, v in args.items():
+            for k, v in inputs.items():
                 self.register_parameter(k, nn.Parameter(v.clone()))
 
-        def forward(self) -> Dict[str, Tensor]:
-            output = fn(**{k: getattr(self, k) for k in args})
-            loss: Tensor = poptorch.identity_loss(output, reduction="sum")
-            return dict(output=output, loss=loss)
+        def forward(self) -> Tuple[Dict[str, Tensor], Tensor]:
+            outputs = fn(**{k: getattr(self, k) for k in inputs})
+            loss = poptorch.identity_loss(
+                sum(
+                    torch.sum(v * grad_outputs.get(k, torch.ones_like(v)).to(v.device))
+                    for k, v in outputs.items()
+                ),
+                reduction="none",
+            )
+            return outputs, loss
 
     module = TestModule()
     optimiser = torch.optim.SGD(module.parameters(), 1.0)
     if device == "ipu":
         options = poptorch.Options()
-        options.useIpuModel(True)
+        options.useIpuModel(not poptorch.ipuHardwareIsAvailable())
         options._popart.setPatterns(patterns)
         step = poptorch.trainingModel(module, options, optimiser)
-        output = step()
+        output, _ = step()
         step.copyWeightsToHost()
     else:
         optimiser.zero_grad()
-        output = module()
-        output["loss"].backward()
+        output, loss = module()
+        loss.backward()
         optimiser.step()
-    return dict(
-        **output,
-        **{f"grad_{k}": args[k] - getattr(module, k).detach() for k in args},
-    )
+    with torch.no_grad():
+        return dict(
+            **output,
+            **{f"grad_{k}": inputs[k] - getattr(module, k) for k in inputs},
+        )
 
 
 @pytest.mark.parametrize("device", ["cpu", "ipu"])
 def test_autograd_proxy(device: str) -> None:
     outputs = run_forward_and_backward(
-        lambda x: pea.autograd_proxy(torch.round(x), 3 * x),
+        lambda x: dict(y=pea.autograd_proxy(torch.round(x), 3 * x)),
         dict(x=torch.tensor(5.7)),
+        grad_outputs=dict(y=torch.tensor(100.0)),
         patterns=dict(AutogradProxyOpPattern=True),
         device=device,
     )
-    torch.testing.assert_close(outputs["loss"], torch.tensor(6.0))
-    torch.testing.assert_close(outputs["grad_x"], torch.tensor(3.0))
+    torch.testing.assert_close(outputs["y"], torch.tensor(6.0))
+    torch.testing.assert_close(outputs["grad_x"], torch.tensor(300.0))
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
@@ -68,17 +78,15 @@ def test_distance_matrix(p: int, dtype: torch.dtype) -> None:
     tensor2 = torch.randn(size=(N, K), dtype=dtype)
 
     output_ipu = run_forward_and_backward(
-        lambda tensor1, tensor2: pea.distance_matrix(tensor1, tensor2, p),
+        lambda tensor1, tensor2: dict(y=pea.distance_matrix(tensor1, tensor2, p)),
         dict(tensor1=tensor1, tensor2=tensor2),
-        patterns={},
         device="ipu",
     )
     output_torch = run_forward_and_backward(
-        lambda tensor1, tensor2: cast(
-            torch.Tensor, (tensor1[:, None] - tensor2[None, :]).norm(p=p, dim=-1)
+        lambda tensor1, tensor2: dict(
+            y=(tensor1[:, None] - tensor2[None, :]).norm(p=p, dim=-1)
         ),
         dict(tensor1=tensor1, tensor2=tensor2),
-        patterns={},
         device="cpu",
     )
 
@@ -86,8 +94,8 @@ def test_distance_matrix(p: int, dtype: torch.dtype) -> None:
     rtol = {torch.float32: 2e-6, torch.float16: 2e-3}[dtype]
 
     torch.testing.assert_close(
-        output_ipu["output"],
-        output_torch["output"],
+        output_ipu["y"],
+        output_torch["y"],
         rtol=rtol,
         atol=atol,
     )
@@ -103,3 +111,101 @@ def test_distance_matrix(p: int, dtype: torch.dtype) -> None:
         rtol=rtol,
         atol=atol,
     )
+
+
+def test_quantisation_cpu() -> None:
+    assert set(
+        pea.quantise_fpx(
+            torch.linspace(-4, 4, steps=100),
+            exponent_bits=2,
+            mantissa_bits=1,
+            rounding="nearest",
+        ).tolist()
+    ) == {sx for x in [0, 0.25, 0.5, 0.75, 1, 1.5, 2, 3] for sx in [x, -x]}
+
+    assert set(
+        pea.quantise_fpx(
+            torch.linspace(-10, 10, steps=1000),
+            exponent_bits=3,
+            mantissa_bits=0,
+            rounding="nearest",
+        )
+        .abs()
+        .tolist()
+    ) == {0, 0.125, 0.25, 0.5, 1, 2, 4, 8}
+
+
+@pytest.mark.parametrize("device", ["cpu", "ipu"])
+def test_quantisation_stochastic_rounding(device: str) -> None:
+    if device == "ipu" and not poptorch.ipuHardwareIsAvailable():
+        pytest.skip("quantise_fpx() requires IPU hardware")
+
+    n = 10000
+    x, grad_y = -1.35, 3.0
+    out = run_forward_and_backward(
+        lambda x: dict(
+            y=pea.quantise_fpx(
+                x, exponent_bits=2, mantissa_bits=1, rounding="stochastic", bwd=True
+            )
+        ),
+        dict(x=torch.full((n,), x)),
+        grad_outputs=dict(y=torch.full((n,), grad_y)),
+        device=device,
+    )
+
+    y_count = collections.Counter(out["y"].tolist())
+    assert y_count.keys() == {-1.5, -1.0}
+    expected_ratio = (1.35 - 1.0) / 0.5
+    nearest_ratio = y_count[-1.5] / sum(y_count.values())
+    std_x3 = 3 * (expected_ratio * (1 - expected_ratio) / n) ** 0.5
+    assert expected_ratio - std_x3 < nearest_ratio < expected_ratio + std_x3
+
+    assert collections.Counter(out["grad_x"].tolist()) == {3.0: n}
+
+
+@pytest.mark.parametrize("device", ["cpu", "ipu"])
+def test_quantisation_variants(device: str) -> None:
+    if device == "ipu" and not poptorch.ipuHardwareIsAvailable():
+        pytest.skip("quantise_fpx() requires IPU hardware")
+
+    # Note: some gymnastics here to get everything into one test, for efficiency
+    def _fn(**args: Tensor) -> Dict[str, Tensor]:
+        return {
+            f"y{suffix}": quantise(  # type:ignore[operator]
+                args[f"x{suffix}"],
+                exponent_bits=4,
+                mantissa_bits=3,
+                rounding="nearest",
+            )
+            for suffix, quantise in [
+                ("", pea.quantise_fpx),
+                ("_ste", pea.quantise_fpx_ste),
+                ("_grad_only", pea.quantise_fpx_grad),
+            ]
+        }
+
+    x = torch.linspace(-300, 300, steps=1000)
+    grad_y = torch.flip(x, (0,))
+    out = run_forward_and_backward(
+        _fn,
+        {name: x for name in ["x", "x_ste", "x_grad_only"]},
+        grad_outputs={name: grad_y for name in ["y", "y_ste", "y_grad_only"]},
+        device=device,
+    )
+
+    def assert_quantised(t: Tensor) -> None:
+        assert len(set(t.tolist())) <= 256
+        torch.testing.assert_close(t.max(), torch.tensor(240.0))
+        torch.testing.assert_close(t.min(), torch.tensor(-240.0))
+
+    # quantise_fpx
+    assert_quantised(out["y"])
+    assert torch.equal(out["grad_x"], torch.zeros_like(x))
+
+    # quantise_fpx_ste
+    assert_quantised(out["y_ste"])
+    assert torch.equal(out["grad_x_ste"], grad_y)
+
+    # quantise_fpx_grad
+    assert torch.equal(out["y_grad_only"], x)
+    assert_quantised(out["grad_x_grad_only"])


### PR DESCRIPTION
Shouldn't be anything too surprising (as mentioned, I think the low end of E5M2 is a bit wrong on IPU, but probably close enough for our purposes & irrelevant if FP8/16 are used together, in any case).

Unfortunately the IPU code doesn't work on IPUModel, so the (CPU) GitHub CI tests are a bit limited.

~~TODO: I need to put some range assertions in the IPU code for exponent & mantissa.~~
